### PR TITLE
Make index title apply to all challenge years

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-        <title>The CPAN Pull Request Challenge 2015</title>
+        <title>The CPAN Pull Request Challenge</title>
         <link rel=stylesheet type="text/css" href="cpan-prc.css">
     </head>
 <body>


### PR DESCRIPTION
The current index page title mentions the year (2015), which was the year in which the challenge first took place.  Removing the year makes the title applicable to all subsequent years of the challenge.
